### PR TITLE
fixed boxscore and mongodb test

### DIFF
--- a/boxscore_core.py
+++ b/boxscore_core.py
@@ -141,12 +141,13 @@ class BoxScore(object):
                         meta_data['time_of_game'] = row.text.split('Game:')[1]
                 except:
                     continue
-            
-            return boxscore_data, meta_data, gametag
+           
+            boxscore_data['meta'] = meta_data
+            return boxscore_data
         else:
             print("Game {} already exists in db. Skipping web-scraping phase...".format(gametag))
             # currently returns empty dicts, but should ideally load from mongodb and return to user
-            return boxscore_data, meta_data, gametag
+            return None
 
     def _get_meta(self,game_url):
         """

--- a/scrape_test.py
+++ b/scrape_test.py
@@ -29,7 +29,7 @@ class TestBoxScore(object):
         # Get boxscore; basic then advanced
         s2013 = BoxScore(year=2013)
         links2013 = s2013._get_game_urls_for_season()
-        boxscore_data,gametag = s2013._get_boxscore(links2013[0])
+        boxscore_data = s2013._get_boxscore(links2013[0])
 
         # load data from static json file
         f = open('./tests/data/season2013gamedata.json','r')
@@ -66,14 +66,14 @@ class TestBoxScore(object):
         url = 'http://www.basketball-reference.com/boxscores/201502270ATL.html'
         ID = '201502270ATL'
         s2014 = BoxScore(year=2014)
-        boxscore_data,gametag = s2014._get_boxscore(url,field_type='basic')
+        boxscore_data = s2014._get_boxscore(url)
         scrape = Scrape()
         assert scrape._ID_exists_in_DB(ID) == False, "ID already exists"
         post_id = scrape._write_to_mongodb(boxscore_data)
-
+        ipdb.set_trace()
         assert scrape.client.game_data.posts.find_one({'GAMETAG':ID}) is not None, "Data never written to db"
         scrape.client.game_data.posts.remove({'_id':post_id})
 
-class TestRoster(object):
-
-    def 
+#class TestRoster(object):
+#
+#    def 


### PR DESCRIPTION
Fixed boxscore so that the meta data is part of the boxscore dictionary. get_boxscore now just returns the boxscore dictionary al set up to be loaded to the database. It doesnt return the 3 different values. If the boxscore already exists, it returns None.